### PR TITLE
feat: mutable request

### DIFF
--- a/ext/bib.ts
+++ b/ext/bib.ts
@@ -42,7 +42,6 @@ export async function createBib(initialUrl: string) {
   document.body.appendChild(bib);
   async function navigateTo(address: string) {
     const _url = new URL(initialUrl);
-    _url.searchParams.set("fakettp", "force");
     frame.src = _url.href;
     url.value = address;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fakettp",
-  "version": "1.6.0-beta",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "fakettp",
-      "version": "1.6.0-beta",
+      "version": "1.7.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fakettp",
-  "version": "1.6.0-beta",
+  "version": "1.7.0",
   "description": "sandbox node core http module in a service worker.",
   "main": "dist/fakettp.js",
   "scripts": {

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -7,7 +7,6 @@ import {
   FIN,
   defaultHost,
   defaultPort,
-  normalizedPort,
   serializeRequest,
   SerializedResponse,
   type ProxyWorkerInstance,
@@ -48,23 +47,6 @@ function onFetch(this: ProxyWorkerInstance, ev: FetchEvent) {
         .then(async (mt) => {
           log("processing fetch event: %s", ev.request.url);
           const requestUrl = new URL(ev.request.url);
-          const forceProxy = true; // requestUrl.searchParams.get("fakettp") === "force";
-          if (
-            !forceProxy &&
-            !isMe(requestUrl) &&
-            !(this.armed && this.host === requestUrl.hostname && normalizedPort(requestUrl) === this.port)
-          ) {
-            log("letting browser handle request: %s", ev.request.url);
-            return resolve(fetch(ev.request));
-          }
-          if (requestUrl.host === globalThis.location.host) {
-            const client = await globalThis.clients.get(ev.clientId);
-            if (!forceProxy && client?.id === mt?.id) {
-              log("refusing to proxy same host request: %s", ev.request.url);
-              log("trace this request in code and move it to an iframe or add ?fakettp=force to the url");
-              return resolve(fetch(ev.request));
-            }
-          }
           const requestSerialized = serializeRequest(ev.request);
           const requestId = requestSerialized.id;
           log("fetch event: %s, id: %d", ev.request.url, requestId);

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -48,7 +48,7 @@ function onFetch(this: ProxyWorkerInstance, ev: FetchEvent) {
         .then(async (mt) => {
           log("processing fetch event: %s", ev.request.url);
           const requestUrl = new URL(ev.request.url);
-          const forceProxy = requestUrl.searchParams.get("fakettp") === "force";
+          const forceProxy = true; // requestUrl.searchParams.get("fakettp") === "force";
           if (
             !forceProxy &&
             !isMe(requestUrl) &&
@@ -93,7 +93,7 @@ function onFetch(this: ProxyWorkerInstance, ev: FetchEvent) {
                 this.listeners.delete(requestId);
                 resolve(fetch(ev.request));
               }
-            }, 100);
+            }, 30000);
           }
         })
         .catch(reject);


### PR DESCRIPTION
Certain properties of the request / socket need to be mutable. They are in node and libraries like express rely on this functionality to rewrite parts of the request object.

Removed the proxy settings. Found it causing issues. Need to revisit it in the future but do not recommend using it for now.